### PR TITLE
Safely get nested navigation params

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,9 @@
 import React from 'react';
 import hoistNonReactStatic from 'hoist-non-react-statics';
 
-const get = (p, o) => p.reduce((xs, x) => (xs && xs[x]) ? xs[x] : null, o)
-
 export const withMappedNavigationProps = SecondOrderWrapperComponent => WrappedComponent => {
   const TargetComponent = props => {
-    const params = get(['navigation', 'state', 'params'], props) || {};
+    const params = props.navigation ? props.navigation.state.params : {};
     
     const { screenProps, ...propsExceptScreenProps } = props;
 

--- a/index.js
+++ b/index.js
@@ -1,9 +1,12 @@
 import React from 'react';
 import hoistNonReactStatic from 'hoist-non-react-statics';
 
+const get = (p, o) => p.reduce((xs, x) => (xs && xs[x]) ? xs[x] : null, o)
+
 export const withMappedNavigationProps = SecondOrderWrapperComponent => WrappedComponent => {
   const TargetComponent = props => {
-    const { navigation: { state: { params } } } = props;
+    const params = get(['navigation', 'state', 'params'], props) || {};
+    
     const { screenProps, ...propsExceptScreenProps } = props;
 
     if (!SecondOrderWrapperComponent) {


### PR DESCRIPTION
If the component didn't have a `navigation` prop the app would red screen as it would be trying to access a nested property on undefined.