### PR TITLE
handle empty params in TargetComponent

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -33,7 +33,7 @@ export function forwardNavigationParams<
 >(SecondOrderWrapperComponent?: SecondOrderWrapperType<ScreenProps>) {
   return function (WrappedComponent: ComponentType<ScreenProps>) {
     const TargetComponent = (props: NavigationAndRoute<ScreenProps>) => {
-      const { params } = props.route;
+      const { params } = props.route || ({} as any);
 
       if (!SecondOrderWrapperComponent) {
         return <WrappedComponent {...props} {...params} />;


### PR DESCRIPTION
- added condition to check for empty params in `TargetComponent`. return empty object, otherwise.

this pr contains fix for empty params. in some cases useful to use the same component as a screen inside the navigator and as a screen for the modal window. for the second variant `props.route` will not contain `params`. to handle this and left `withForwardedNavigationParams` i added a checker for empty `params`

<details>
  <summary>Screenshot  with error</summary>
  
![image](https://user-images.githubusercontent.com/32811631/154082404-498cfe59-c199-476c-8306-8a7eac92c6b7.png)
  
</details>